### PR TITLE
Add hasDocker and use it in the integration tests

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Revision history for docker-tmp-proc
 
+## Unreleased changes
+
+* Add hasDocker function to determine if docker is present
+
+
 ## 0.2.0.0 -- 2019-02-18
 
 * Added integration tests, removed unnecessary internal features from the public

--- a/docker-tmp-proc.cabal
+++ b/docker-tmp-proc.cabal
@@ -41,6 +41,7 @@ test-suite docker-tmp-proc-test
                     Test.NoopServerSpec
                     Test.TmpProc.Postgres
                     Test.TmpProc.Redis
+                    Test.TmpProc.Hspec
   hs-source-dirs:   test
   build-depends:    base
                   , bytestring

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -16,8 +16,9 @@ main :: IO ()
 main = do
   hSetBuffering stdin NoBuffering
   hSetBuffering stdout NoBuffering
+  noDocker <- not <$> hasDocker
   hspec $ do
     let noReset = [Postgres.mkNoResetProc, Redis.mkNoResetProc]
-    mapM_ Noop.noopSpec noReset
-    Postgres.spec
-    Redis.spec
+    mapM_ (Noop.noopSpec noDocker) noReset
+    Postgres.spec noDocker
+    Redis.spec noDocker

--- a/test/Test/NoopServerSpec.hs
+++ b/test/Test/NoopServerSpec.hs
@@ -9,19 +9,21 @@ import qualified Data.Text                      as Text
 import           System.Docker.TmpProc
 
 import           Test.NoopServer                (noopSetup)
+import           Test.TmpProc.Hspec             (noDockerSpec)
 
 
-noopSpec :: TmpProc -> Spec
-noopSpec tp = do
+noopSpec :: Bool -> TmpProc -> Spec
+noopSpec noDocker tp = do
   let name = procImageName tp
       desc = "with image " ++ (Text.unpack name) ++ " and a noop server"
 
-  beforeAll (noopSetup tp) $ afterAll cleanup $ do
-    describe desc $ do
-      context "invoking reset" $ do
-        it "should not fail" $ \oh -> do
-          reset name oh `shouldReturn` ()
+  if noDocker then noDockerSpec desc else do
+    beforeAll (noopSetup tp) $ afterAll cleanup $ do
+      describe desc $ do
+        context "invoking reset" $ do
+          it "should not fail" $ \oh -> do
+            reset name oh `shouldReturn` ()
 
-      context "obtaining the process' URI" $ do
-        it "should succeed" $ \oh -> do
-          (isRight $ procURI name oh) `shouldBe` True
+        context "obtaining the process' URI" $ do
+          it "should succeed" $ \oh -> do
+            (isRight $ procURI name oh) `shouldBe` True

--- a/test/Test/TmpProc/Hspec.hs
+++ b/test/Test/TmpProc/Hspec.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.TmpProc.Hspec (noDockerSpec) where
+
+import           Test.Hspec
+
+-- | Used as pending alternative when docker is unavailable.
+noDockerSpec :: String -> Spec
+noDockerSpec desc = describe desc $ do
+  it "cannot run as docker is unavailable" $ pending

--- a/test/Test/TmpProc/Postgres.hs
+++ b/test/Test/TmpProc/Postgres.hs
@@ -14,16 +14,18 @@ import           System.Docker.TmpProc
 import           System.Docker.TmpProc.Postgres
 
 import           Test.NoopServer                (noopPort)
+import           Test.TmpProc.Hspec             (noDockerSpec)
 
 
-spec :: Spec
-spec = do
+spec :: Bool -> Spec
+spec noDocker = do
   let desc = "postgres: image " ++ (Text.unpack $ procImageName resetProc)
-  beforeAll (pgSetup resetProc) $ afterAll cleanup $ do
-    describe desc $ do
-      context "invoking a simple SQL reset action" $ do
-        it "should not fail" $ \oh -> do
-          reset (procImageName resetProc) oh `shouldReturn` ()
+  if noDocker then noDockerSpec desc else do
+    beforeAll (pgSetup resetProc) $ afterAll cleanup $ do
+      describe desc $ do
+        context "invoking a simple SQL reset action" $ do
+          it "should not fail" $ \oh -> do
+            reset (procImageName resetProc) oh `shouldReturn` ()
 
 
 -- | A testProc that executes the user-provided reset action.

--- a/test/Test/TmpProc/Redis.hs
+++ b/test/Test/TmpProc/Redis.hs
@@ -16,16 +16,18 @@ import           System.Docker.TmpProc
 import           System.Docker.TmpProc.Redis
 
 import           Test.NoopServer             (noopPort)
+import           Test.TmpProc.Hspec          (noDockerSpec)
 
 
-spec :: Spec
-spec = do
+spec :: Bool -> Spec
+spec noDocker = do
   let desc = "redis: image " ++ (Text.unpack $ procImageName resetProc)
-  beforeAll (rdsSetup resetProc) $ afterAll cleanup $ do
-    describe desc $ do
-      context "invoking a simple redis action" $ do
-        it "should not fail" $ \oh -> do
-          reset (procImageName resetProc) oh `shouldReturn` ()
+  if noDocker then noDockerSpec desc else do
+    beforeAll (rdsSetup resetProc) $ afterAll cleanup $ do
+      describe desc $ do
+        context "invoking a simple redis action" $ do
+          it "should not fail" $ \oh -> do
+            reset (procImageName resetProc) oh `shouldReturn` ()
 
 
 -- | A testProc that executes the user-provided reset action.


### PR DESCRIPTION
- hasDocker determines if the docker daemon is accessible

- the specs are updated to be replaced with a single pending flag when it is
  not.