### PR TITLE
Trap exceptions in the app thread and throw them in the caller

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Revision history for docker-tmp-proc
 
+## 0.3.2.0 -- 2019-04-01
+
+* Make the run*Server functions throw exceptions in app threads to the calling
+  thread.
+
 ## 0.3.1.0 -- 2019-02-26
 
 * Add new public functions that allow TLS-protected endpoints

--- a/docker-tmp-proc.cabal
+++ b/docker-tmp-proc.cabal
@@ -1,5 +1,5 @@
 name:               docker-tmp-proc
-version:            0.3.1.0
+version:            0.3.2.0
 synopsis:           Use docker to run 'tmp' procesess
 description:        Use processes run in docker containers as temporary processes
                     similarly to the use of files in the tmp file system


### PR DESCRIPTION
This is right thing to do since this library is intended for use in tests and
not production code.